### PR TITLE
upgrade to Awestruct 0.5.4.rc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-#gem 'awestruct', '~> 0.5.2.1'	# Framework for creating static HTML sites
-gem 'awestruct', :github => 'mojavelinux/awestruct', :branch => 'integration'
+gem 'awestruct', '~> 0.5.4.rc'	# Framework for creating static HTML sites
+#gem 'awestruct', :github => 'mojavelinux/awestruct', :branch => 'integration'
 gem 'uglifier', '~> 2.0.1'	# Ruby wrapper for UglifyJS JavaScript compressor
 gem 'cssminify', '~> 1.0.2'	# CSS compression using YUI compressor
 gem 'less', '~> 2.3.2'		# Invoke the Less CSS compiler from Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,12 @@
-GIT
-  remote: git://github.com/mojavelinux/awestruct.git
-  revision: 5523b7f299be926115f9c883d13f58cb981ce7f8
-  branch: integration
+GEM
+  remote: https://rubygems.org/
   specs:
-    awestruct (0.5.3)
+    POpen4 (0.1.4)
+      Platform (>= 0.4.0)
+      open4
+    Platform (0.4.0)
+    asciidoctor (0.1.4)
+    awestruct (0.5.4.rc)
       bootstrap-sass (>= 2.3.1.0)
       compass (>= 0.12.1)
       compass-960-plugin (~> 0.10.4)
@@ -14,21 +17,12 @@ GIT
       rest-client (>= 1.6.7)
       ruby-s3cmd (~> 0.1.5)
       tilt (>= 1.3.6)
-      zurb-foundation (>= 4.0.9)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    POpen4 (0.1.4)
-      Platform (>= 0.4.0)
-      open4
-    Platform (0.4.0)
-    asciidoctor (0.1.4)
+      zurb-foundation (~> 4)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     chunky_png (1.2.8)
     coderay (1.1.0)
-    commonjs (0.2.6)
+    commonjs (0.2.7)
     compass (0.12.2)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -36,18 +30,17 @@ GEM
     compass-960-plugin (0.10.4)
       compass (>= 0.10.0)
     cssminify (1.0.2)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
+    execjs (2.0.2)
     ffi (1.9.0)
     fssm (0.2.10)
     git (1.2.6)
     haml (4.0.3)
       tilt
-    htmlcompressor (0.0.6)
+    htmlcompressor (0.0.7)
       yui-compressor (~> 0.9.6)
     json (1.7.7)
     kramdown (1.0.2)
-    less (2.3.2)
+    less (2.3.3)
       commonjs (~> 0.2.6)
     libv8 (3.11.8.17)
     listen (1.3.1)
@@ -55,20 +48,20 @@ GEM
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     mime-types (1.25)
-    multi_json (1.7.3)
+    multi_json (1.8.0)
     nokogiri (1.5.10)
     open4 (1.3.0)
     rack (1.5.2)
     rb-fsevent (0.9.3)
-    rb-inotify (0.9.1)
+    rb-inotify (0.9.2)
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
-    ref (1.0.4)
+    ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     ruby-s3cmd (0.1.5)
-    sass (3.2.10)
+    sass (3.2.11)
     therubyracer (0.11.4)
       libv8 (~> 3.11.8.12)
       ref
@@ -79,7 +72,7 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
     yui-compressor (0.9.6)
       POpen4 (>= 0.1.4)
-    zurb-foundation (4.3.1)
+    zurb-foundation (4.3.2)
       sass (>= 3.2.0)
 
 PLATFORMS
@@ -87,7 +80,7 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor (~> 0.1.4)
-  awestruct!
+  awestruct (~> 0.5.4.rc)
   coderay (~> 1.1.0)
   cssminify (~> 1.0.2)
   git (~> 1.2.6)

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -11,16 +11,16 @@ html_minifier: disabled
 
 asciidoctor:
   :attributes:
-    icons: 'font'
+    icons: font
     sectanchors: true
     toclevels: 3
     numbered: true
-    docinfo: true
+    docinfo: ''
     source-highlighter: coderay
     backend: html5
     doctype: book    
     ## Leave this empty!!
-    imagesdir: 
+    imagesdir: ''
     experimental: true
 # Merge multiple JavaScript files to improve performance
 fileMerger:


### PR DESCRIPTION
I've verified that Awestruct 0.5.4.rc properly renders AsciiDoc files. It also has some fixes that the integration branch currently in use does not.

I also replaced empty values with a literal empty string in the Asciidoctor config to make the intent more clear.
