### PR TITLE
Red Hat tab dropdown support and updated bootstrap-community theme references

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -4,6 +4,9 @@ title: Infinispan
 # Project id name
 project: infinispan
 
+# Project full name
+project_name: Infinispan
+
 # Default minify settings
 css_minifier: disabled
 js_minifier: disabled
@@ -77,8 +80,8 @@ profiles:
     jborg_images_url: http://static.jboss.org/theme/images
     jborg_js_url: http://static.jboss.org/theme/js
     project_images_url: http://static.jboss.org/images/example
-    bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.1/bootstrap-community
-    bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.1/bootstrap-community      
+    bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.4/bootstrap-community
+    bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.4/bootstrap-community      
     # jborg_fonts_url: /cache/static.jboss.org/theme/fonts
     # jborg_images_url: /cache/static.jboss.org/theme/images
     # jborg_js_url: /cache/static.jboss.org/theme/js
@@ -90,8 +93,8 @@ profiles:
     jborg_images_url: http://static.jboss.org/theme/images
     jborg_js_url: http://static.jboss.org/theme/js
     project_images_url: http://static.jboss.org/images/example
-    bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.1/bootstrap-community
-    bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.1/bootstrap-community
+    bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.4/bootstrap-community
+    bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.4/bootstrap-community
     base_url: http://infinispan.github.io
   production:
     minified: .min
@@ -102,8 +105,8 @@ profiles:
     jborg_images_url: http://static.jboss.org/theme/images
     jborg_js_url: http://static.jboss.org/theme/js
     project_images_url: http://static.jboss.org/images/example
-    bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.1/bootstrap-community
-    bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.1/bootstrap-community
+    bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.4/bootstrap-community
+    bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.4/bootstrap-community
     base_url: http://infinispan.github.io
     google_analytics: UA-8601422-1
     deploy:

--- a/_layouts/project.html.haml
+++ b/_layouts/project.html.haml
@@ -1,37 +1,105 @@
+
 !!! 5
 %html(lang="en")
   %head
-    %title #{page.title ? page.title : page.simple_name.capitalize } · #{site.title}
-    = partial( page.head_partial.nil? ? 'head.html.haml' : page.head_partial )
-
+    = partial( page.head_partial.nil? ? 'head.html.haml' : page.head_partial , { "real_page" => page } )
   %body
-    / begin accesibility skip to top
-    %ul#top.visuallyhidden
-      %li
-        %a{:accesskey => "n", :href => "#nav", :title => "Skip to navigation"} Skip to navigation
-      %li
-        %a{:accesskey => "c", :href => "#page", :title => "Skip to content"} Skip to content
-    .container#content
+    %div{:id => "#{page.subproject ? 'subproject' : ''}"}
+      / begin accesibility skip to top
+      %ul#top.visuallyhidden
+        %li
+          %a{:accesskey => "n", :href => "#nav", :title => "Skip to navigation"} Skip to navigation
+        %li
+          %a{:accesskey => "c", :href => "#page", :title => "Skip to content"} Skip to content
+      .container#content
 
-      .dropup
-        %a#tab.tabnav-closed{:href => "https://www.jboss.org"} Red Hat
+        .dropup
+          %div#ajbossproject A JBoss Project
+          %a#tab.tabnav-closed{:href => "#"} Red Hat
+          %script
+            window.addEventListener('load', function() { renderTabzilla("#{site.project_name}","#{site.project}") }, false);
 
-      = partial( page.banner_partial.nil? ? 'banner.html.haml' : page.banner_partial )
+        - if page.subproject
+          = partial( page.navparent_partial.nil? ? 'navparent.html.haml' : page.navparent_partial , { "real_page" => page } )
 
-      = partial( page.nav_partial.nil? ? 'nav.html.haml' : page.nav_partial )
+        = partial( page.banner_partial.nil? ? 'banner.html.haml' : page.banner_partial , { "real_page" => page } )
 
-      ~ content
+        = partial( page.nav_partial.nil? ? 'nav.html.haml' : page.nav_partial , { "real_page" => page } )
 
-    = partial( page.projectfooter_partial.nil? ? 'projectfooter.html.haml' : page.projectfooter_partial )
+        ~ content
 
-    = partial( page.companyfooter_partial.nil? ? 'companyfooter.html.haml' : page.companyfooter_partial )
+      = partial( page.projectfooter_partial.nil? ? 'projectfooter.html.haml' : page.projectfooter_partial , { "real_page" => page } )
 
-    %span.backToTop
-      %a{:href => "#top"} back to top
+      = partial( page.companyfooter_partial.nil? ? 'companyfooter.html.haml' : page.companyfooter_partial , { "real_page" => page } )
 
-    %script(src="#{pageStyle ? site[pageStyle].bootstrap_js_url : site.bootstrap_js_url}#{site.minified}.js")
-    - if page.bottom_javascripts
-      - page.bottom_javascripts.each do |javascript|
-        %script{:src=>javascript, :type=>'text/javascript'}
-    - if site.google_analytics
-      = google_analytics_async
+      %span.backToTop
+        %a{:href => "#top"} back to top
+
+      %script(src="#{pageStyle ? site[pageStyle].bootstrap_js_url : site.bootstrap_js_url}#{site.minified}.js")
+      - if page.bottom_javascripts
+        - page.bottom_javascripts.each do |javascript|
+          %script{:src=>javascript, :type=>'text/javascript'}
+
+      - if site.profile.eql?("staging") or site.profile.eql?("production")
+        :plain
+          <!-- begin eloqua tracking -->
+          <script type='text/javascript' language='JavaScript' src='http://www.redhat.com/j/elqNow/elqCfg.js'></script>
+          <script type='text/javascript' language='JavaScript' src='http://www.redhat.com/j/elqNow/elqImg.js'></script>
+          <!-- end eloqua tracking -->
+
+          <div id="oTags">
+            <script type="text/javascript" src="//www.#{site.profile.eql?('staging') ? 'stage.' : ''}redhat.com/j/s_code.js"></script>
+            <script type="text/javascript"><!--
+            var coreUrl = encodeURI(document.URL.split("?")[0]).replace(/-/g," ");
+            var urlSplit = coreUrl.toLowerCase().split(/\//);
+            var urlLast = urlSplit[urlSplit.length-1];
+            var pageNameString = "";
+            var siteName = "";
+            var minorSectionIndex = 3
+            if (urlLast == "") {
+                urlSplit.splice(-1,1);
+            }
+            if (urlLast.search(/\./) >= 0) {
+                if (urlLast == "index.html") {
+                    urlSplit.splice(-1,1);
+                }
+                else {
+                    urlSplit[urlSplit.length-1] = urlLast.split(".").splice(0,1);
+                }
+            }
+            siteName = urlSplit[2].split(".")[1];
+            s.prop14 = s.eVar27 = siteName || "";
+            s.prop15 = s.eVar28 = urlSplit[minorSectionIndex] || "";
+            s.prop16 = s.eVar29 = urlSplit[minorSectionIndex+1] || "";
+            pageNameString = urlSplit.splice(3).join(" | ");
+            s.pageName = "jboss | community | " + siteName + " | " + pageNameString;
+            s.server = "jboss";
+            s.channel = "jboss | community";
+            s.prop4 = s.eVar23 = encodeURI(document.URL);
+            s.prop21 = s.eVar18 = coreUrl;
+            s.prop2 = s.eVar22 = "en";
+            s.prop3 = s.eVar19 = "us";
+            //--></script>
+            <script type="text/javascript" src="//www.#{site.profile.eql?('staging') ? 'stage.' : ''}redhat.com/j/rh_omni_footer.js"></script>
+            <script language="JavaScript" type="text/javascript"><!--
+            if(navigator.appVersion.indexOf('MSIE')>=0)document.write(unescape('%3C')+'\!-'+'-')
+            //--></script>
+            <noscript><a href="http://www.omniture.com" title="Web Analytics"><img
+            src="https://smtrcs.redhat.com/b/ss/redhatcom,redhatglobal/1/H.25.4--NS/0?[AQB]&cdp=3&[AQE]"
+            height="1" width="1" border="0" alt="" /></a></noscript>
+          </div>
+          <!-- End oTags -->
+
+          <!-- Google Analytics part -->
+          <script type="text/javascript">
+          var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+          document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+          </script>
+          <script type="text/javascript">
+          try {
+          var pageTracker = _gat._getTracker("UA-10656779-1");
+          pageTracker._trackPageview();
+          } catch(err) {}</script>
+
+        - if site.google_analytics
+          = google_analytics_async


### PR DESCRIPTION
Hi,

All project sites need to have Red Hat logo in the footer and Red Hat tab dropdown in the right upper corner. We've introduced the second feature in bootstrap-community in recent releases therefore I created a simple pull request which updates references on your site to the newest version of our resources and uses our newest main project.html.haml layout file. I looked around the site and everything seems to be working fine after the change but please double check.