### PR TITLE
Adding in reference to new cluster executor tutorial

### DIFF
--- a/tutorials.html.haml
+++ b/tutorials.html.haml
@@ -135,6 +135,13 @@ title: Tutorials
           Run code concurrently on all nodes in the cluster
       %tr
         %td
+          %a{:href=>"/tutorials/simple/clusterexec/"}
+            %b Cluster Executor
+        %td
+          Run code concurrently on all nodes in the cluster, using a ClusterExecutor which doesn't require a cache.
+
+      %tr
+        %td
           %a{:href=>"/tutorials/simple/spark/"}
             %b Integration with Apache Spark
         %td

--- a/tutorials/simple/clusterexec.html.haml
+++ b/tutorials/simple/clusterexec.html.haml
@@ -1,0 +1,19 @@
+---
+layout: tutorial
+title: Cluster Executor Tutorial
+---
+%script(src="/javascripts/infinispan.js")
+.row
+  %ul.breadcrumb
+    %li
+      %a{:href => "/tutorials"} Tutorials
+    %li.active Cluster Executor
+
+.row
+  %h2 Cluster Executor
+  %p
+    Performing a common task on all nodes in the cluster
+  .alert.alert-info
+    This tutorial works best when multiple instances are executed at the same time on the same machine/network so that the nodes form a cluster.
+  = partial( 'embed-github-file.html.haml', {"repo" => "infinispan/infinispan-simple-tutorials", "path" => "clusterexec/src/main/java/org/infinispan/tutorial/simple/clusterexec/InfinispanClusterExec.java"} )
+


### PR DESCRIPTION
This can be integrated only after https://github.com/infinispan/infinispan-simple-tutorials/pull/11 is completed.