### PR TITLE
updating link pointing to JDG away from 404

### DIFF
--- a/index.html.haml
+++ b/index.html.haml
@@ -117,7 +117,7 @@ title: Infinispan Homepage
       .panel-body
         %h4 
           Get 
-          %a{:href => "http://www.redhat.com/promo/infspn2jdg/"}
+          %a{:href => "https://www.redhat.com/en/technologies/jboss-middleware/data-grid"}
             JBoss Data Grid, 
           a version of Infinispan supported by 
           %a{:href => "http://www.redhat.com"}


### PR DESCRIPTION
https://github.com/infinispan/infinispan.github.io/issues/36

Current link on index.html.haml under "Paid Support" linking to JBoss Data Grid points to a 404. Updating to point to the current JDG landing page.