### PR TITLE
ISPN-10200 Support serverng + legacy server downloads

### DIFF
--- a/_config/ispn.yml
+++ b/_config/ispn.yml
@@ -22,7 +22,7 @@ stable:
      all: https://downloads.jboss.org/infinispan/9.4.15.Final/infinispan-9.4.15.Final-all.zip
      bin: https://downloads.jboss.org/infinispan/9.4.15.Final/infinispan-9.4.15.Final-minimal.zip
      server: https://downloads.jboss.org/infinispan/9.4.15.Final/infinispan-server-9.4.15.Final.zip
-     as7modules: https://downloads.jboss.org/infinispan/9.4.15.Final/infinispan-wildfly-modules-9.4.15.Final.zip
+     wfmodules: https://downloads.jboss.org/infinispan/9.4.15.Final/infinispan-wildfly-modules-9.4.15.Final.zip
    docs:
      home: /docs/stable/index.html
      user_guide: /docs/stable/user_guide/user_guide.html
@@ -46,7 +46,7 @@ unstable:
      all: https://downloads.jboss.org/infinispan/10.0.0.Beta3/infinispan-10.0.0.Beta3-all.zip
      bin: https://downloads.jboss.org/infinispan/10.0.0.Beta3/infinispan-10.0.0.Beta3-minimal.zip
      server: https://downloads.jboss.org/infinispan/10.0.0.Beta3/infinispan-server-10.0.0.Beta3.zip
-     as7modules: https://downloads.jboss.org/infinispan/10.0.0.Beta3/infinispan-wildfly-modules-10.0.0.Beta3.zip
+     wfmodules: https://downloads.jboss.org/infinispan/10.0.0.Beta3/infinispan-wildfly-modules-10.0.0.Beta3.zip
    docs:
      home: /docs/dev/index.html
      user_guide: /docs/dev/user_guide/user_guide.html
@@ -74,7 +74,7 @@ old:
     all: https://downloads.jboss.org/infinispan/9.3.6.Final/infinispan-9.3.6.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/9.3.6.Final/infinispan-9.3.6.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/9.3.6.Final/infinispan-server-9.3.6.Final.zip
-    as7modules: https://downloads.jboss.org/infinispan/9.3.6.Final/infinispan-wildfly-modules-9.3.6.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/9.3.6.Final/infinispan-wildfly-modules-9.3.6.Final.zip
     docs:
       home: /docs/9.3.x/index.html
       user_guide: /docs/9.3.x/user_guide/user_guide.html
@@ -96,7 +96,7 @@ old:
     all: https://downloads.jboss.org/infinispan/9.2.5.Final/infinispan-9.2.5.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/9.2.5.Final/infinispan-9.2.5.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/9.2.5.Final/infinispan-server-9.2.5.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/9.2.5.Final/infinispan-wildfly-modules-9.2.5.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/9.2.5.Final/infinispan-wildfly-modules-9.2.5.Final.zip
     docs:
       home: /docs/9.2.x/index.html
       user_guide: /docs/9.2.x/user_guide/user_guide.html
@@ -118,7 +118,7 @@ old:
     all: https://downloads.jboss.org/infinispan/9.1.7.Final/infinispan-9.1.7.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/9.1.7.Final/infinispan-9.1.7.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/9.1.7.Final/infinispan-server-9.1.7.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/9.1.7.Final/infinispan-wildfly-modules-9.1.7.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/9.1.7.Final/infinispan-wildfly-modules-9.1.7.Final.zip
     docs:
       home: /docs/9.1.x/index.html
       user_guide: /docs/9.1.x/user_guide/user_guide.html
@@ -140,7 +140,7 @@ old:
     all: https://downloads.jboss.org/infinispan/9.0.3.Final/infinispan-9.0.3.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/9.0.3.Final/infinispan-9.0.3.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/9.0.3.Final/infinispan-server-9.0.3.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/9.0.3.Final/infinispan-wildfly-modules-9.0.3.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/9.0.3.Final/infinispan-wildfly-modules-9.0.3.Final.zip
     docs:
       home: /docs/9.0.x/index.html
       user_guide: /docs/9.0.x/user_guide/user_guide.html
@@ -162,7 +162,7 @@ old:
     all: https://downloads.jboss.org/infinispan/8.2.8.Final/infinispan-8.2.8.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/8.2.8.Final/infinispan-8.2.8.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/8.2.8.Final/infinispan-server-8.2.8.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/8.2.8.Final/infinispan-as-embedded-modules-8.2.8.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/8.2.8.Final/infinispan-as-embedded-modules-8.2.8.Final.zip
     docs:
       home: /docs/8.2.x/index.html
       user_guide: /docs/8.2.x/user_guide/user_guide.html
@@ -184,7 +184,7 @@ old:
     all: https://downloads.jboss.org/infinispan/8.1.3.Final/infinispan-8.1.3.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/8.1.3.Final/infinispan-8.1.3.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/8.1.3.Final/infinispan-server-8.1.3.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/8.1.3.Final/infinispan-as-embedded-modules-8.1.3.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/8.1.3.Final/infinispan-as-embedded-modules-8.1.3.Final.zip
     docs:
       home: /docs/8.1.x/index.html
       user_guide: /docs/8.1.x/user_guide/user_guide.html
@@ -206,7 +206,7 @@ old:
     all: https://downloads.jboss.org/infinispan/8.0.2.Final/infinispan-8.0.2.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/8.0.2.Final/infinispan-8.0.2.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/8.0.2.Final/infinispan-server-8.0.2.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/8.0.2.Final/infinispan-as-embedded-modules-8.0.2.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/8.0.2.Final/infinispan-as-embedded-modules-8.0.2.Final.zip
     docs:
       home: /docs/8.0.x/index.html
       user_guide: /docs/8.0.x/user_guide/user_guide.html
@@ -228,7 +228,7 @@ old:
     all: https://downloads.jboss.org/infinispan/7.2.5.Final/infinispan-7.2.5.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/7.2.5.Final/infinispan-7.2.5.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/7.2.5.Final/infinispan-server-7.2.5.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/7.2.5.Final/infinispan-as-embedded-modules-7.2.5.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/7.2.5.Final/infinispan-as-embedded-modules-7.2.5.Final.zip
     docs:
       home: /docs/7.2.x/index.html
       user_guide: /docs/7.2.x/user_guide/user_guide.html
@@ -250,7 +250,7 @@ old:
     all: https://downloads.jboss.org/infinispan/7.1.1.Final/infinispan-7.1.1.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/7.1.1.Final/infinispan-7.1.1.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/7.1.1.Final/infinispan-server-7.1.1.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/7.1.1.Final/infinispan-as-embedded-modules-7.1.1.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/7.1.1.Final/infinispan-as-embedded-modules-7.1.1.Final.zip
     docs:
       home: /docs/7.1.x/index.html
       user_guide: /docs/7.1.x/user_guide/user_guide.html
@@ -272,7 +272,7 @@ old:
     all: https://downloads.jboss.org/infinispan/7.0.3.Final/infinispan-7.0.3.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/7.0.3.Final/infinispan-7.0.3.Final-minimal.zip
     server: https://downloads.jboss.org/infinispan/7.0.3.Final/infinispan-server-7.0.3.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/7.0.3.Final/infinispan-as-embedded-modules-7.0.3.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/7.0.3.Final/infinispan-as-embedded-modules-7.0.3.Final.zip
     docs:
       home: /docs/7.0.x/index.html
       user_guide: /docs/7.0.x/user_guide/user_guide.html
@@ -294,7 +294,7 @@ old:
     all: https://downloads.jboss.org/infinispan/6.0.2.Final/infinispan-6.0.2.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/6.0.2.Final/infinispan-6.0.2.Final-bin.zip
     server: https://downloads.jboss.org/infinispan/6.0.2.Final/infinispan-server-6.0.2.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/6.0.2.Final/infinispan-as-modules-6.0.2.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/6.0.2.Final/infinispan-as-modules-6.0.2.Final.zip
     docs:
       home: /docs/6.0.x/index.html
       user_guide: /docs/6.0.x/user_guide/user_guide.html
@@ -312,7 +312,7 @@ old:
     all: https://downloads.jboss.org/infinispan/5.3.0.Final/infinispan-5.3.0.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/5.3.0.Final/infinispan-5.3.0.Final-bin.zip
     server: https://downloads.jboss.org/infinispan/5.3.0.Final/infinispan-server-5.3.0.Final-bin.zip
-    as7modules: https://downloads.jboss.org/infinispan/5.3.0.Final/infinispan-as-modules-5.3.0.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/5.3.0.Final/infinispan-as-modules-5.3.0.Final.zip
     maven_latest: 5.3.0.Final
     docs:
       home: /docs/5.3.x/index.html
@@ -331,7 +331,7 @@ old:
     all: https://downloads.jboss.org/infinispan/5.2.1.Final/infinispan-5.2.1.Final-all.zip
     bin: https://downloads.jboss.org/infinispan/5.2.1.Final/infinispan-5.2.1.Final-bin.zip
     server: https://downloads.jboss.org/infinispan/5.2.1.Final/infinispan-5.2.1.Final-server.zip
-    as7modules: https://downloads.jboss.org/infinispan/5.2.1.Final/infinispan-as-modules-5.2.1.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/5.2.1.Final/infinispan-as-modules-5.2.1.Final.zip
     maven_latest: 5.2.13.Final
     docs:
       javadocs: https://docs.jboss.org/infinispan/5.2/apidocs/

--- a/_partials/download-tbl-row.html.haml
+++ b/_partials/download-tbl-row.html.haml
@@ -31,11 +31,18 @@
     %a{:href => release_info.server.to_s + ".sha1" }
       (SHA-1)
     %br
-    - if release_info.as7modules?
-      %a{:href => release_info.as7modules}
+    - if release_info.wfmodules?
+      %a{:href => release_info.wfmodules}
         %i.icon-download-alt
         WildFly modules
-      %a{:href => release_info.as7modules.to_s + ".sha1" }
+      %a{:href => release_info.wfmodules.to_s + ".sha1" }
+        (SHA-1)
+    - if release_info.wfserver?
+      %br
+      %a{:href => release_info.wfserver}
+        %i.icon-download-alt
+        Legacy WildFly-based Server
+      %a{:href => release_info.wfserver.to_s + ".sha1" }
         (SHA-1)
   %td.text-center
     = partial("maven-coords-link.html.haml", {"artifactId" => "infinispan-core", "version_stable" => release_info.maven_latest, "modal_id" => release_version})

--- a/download.html.haml
+++ b/download.html.haml
@@ -45,11 +45,14 @@ title: Download
         SHA-1
       Contains the Infinispan server runtime for use as a remote data grid
       %br
+      - if site.ispn.unstable.download.has_key?("wfserver")
+        %a{:href => "#{site.ispn.unstable.downlad.wfserver}"} Legacy WildFly-based server
+        %br
     .col-md-3.text-center
-      %a.btn.btn-warning.btn-sm{:href => site.ispn.unstable.download.as7modules}
+      %a.btn.btn-warning.btn-sm{:href => site.ispn.unstable.download.wfmodules}
         %i.icon-download-alt
         WF modules
-      %a.btn.btn-warning.btn-sm{:href => site.ispn.unstable.download.as7modules.to_s + ".sha1" }
+      %a.btn.btn-warning.btn-sm{:href => site.ispn.unstable.download.wfmodules.to_s + ".sha1" }
         %i.icon-download-alt
         SHA-1
       Packaged modules for deploying in WildFly/JBoss EAP
@@ -115,11 +118,14 @@ title: Download
       SHA-1
     Contains the Infinispan server runtime for use as a remote data grid
     %br
+    - if site.ispn.stable.download.has_key?("wfserver")
+      %a{:href => "#{site.ispn.stable.downlad.wfserver}"} Legacy WildFly-based server
+      %br
   .col-md-3.text-center
-    %a.btn.btn-success.btn-sm{:href => site.ispn.stable.download.as7modules}
+    %a.btn.btn-success.btn-sm{:href => site.ispn.stable.download.wfmodules}
       %i.icon-download-alt
       WF modules
-    %a.btn.btn-success.btn-sm{:href => site.ispn.stable.download.as7modules.to_s + ".sha1" }
+    %a.btn.btn-success.btn-sm{:href => site.ispn.stable.download.wfmodules.to_s + ".sha1" }
       %i.icon-download-alt
       SHA-1  
     Packaged modules for deploying in WildFly/JBoss EAP


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10200

Adds support for downloading both the serverng distribution as well as the old legacy WildFly-based server distribution