### PR TITLE
Pipeline for operator docs

### DIFF
--- a/_config/ispn.yml
+++ b/_config/ispn.yml
@@ -883,3 +883,6 @@ integrations:
          5.1.0.Final:
            release_date: 2017/03/01
            release_notes: https://in.relation.to/2017/03/02/hibernate-ogm-5-1-Final-released/
+ispn-operator:
+    master:
+      zip-url: https://github.com/infinispan/infinispan-operator/archive/master.zip

--- a/bin/fetch_docs.rb
+++ b/bin/fetch_docs.rb
@@ -139,6 +139,22 @@ end
   end
 end
 
+# and then it's operator's turn
+cfg["ispn-operator"].each do |version, sub|
+  puts "#{version} wget"
+  zipUrl=sub["zip-url"]
+  puts "#{version} wget #{zipUrl}"
+  %x( wget #{zipUrl} -O _tmp.zip)
+  %x( unzip _tmp.zip "*documentation/*" -d _tmp)
+  Dir.glob("_tmp/**/*.adoc").each do |f|
+    %x( asciidoctor #{f} )
+  end
+  Dir.glob("_tmp/**/*.asciidoc").each do |f|
+    %x( asciidoctor #{f} )
+  end
+  %x( mkdir -p _site/infinispan-operator/#{version} )
+  %x( mv _tmp/infinispan-operator*/* "_site/infinispan-operator/#{version}" )
+end
 versions_xml_file.puts("</versions>");
 versions_xml_file.close()
 


### PR DESCRIPTION
This PR builds documentation from infinispan-operator asciidoc.
Every URL in ispn.yml file matching ispn-operator.{version}.zip-url is download and processed with asciidoctor.
Processed docs folder is  _site/infinispan-operator/{version}/documentation/asciidoc