### PR TITLE
add operator images

### DIFF
--- a/_config/ispn.yml
+++ b/_config/ispn.yml
@@ -12,17 +12,17 @@
 # -----------------------------
 stable:
   minor_version: 11.0
-  version: 11.0.3.Final
-  maven_latest: 11.0.3.Final
-  release_date: 2020/08/06
-  fixed_issues: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310799&version=12346470
+  version: 11.0.4.Final
+  maven_latest: 11.0.4.Final
+  release_date: 2020/10/02
+  fixed_issues: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310799&version=12346882
   codename: Corona Extra
   whats_new: Async XSite with conflict resolution, non-blocking everywhere, server security usability, etc...
   download:
-    server: https://downloads.jboss.org/infinispan/11.0.3.Final/infinispan-server-11.0.3.Final.zip
-    wfmodules: https://downloads.jboss.org/infinispan/11.0.3.Final/infinispan-wildfly-modules-11.0.3.Final.zip
-    docker: quay.io/infinispan/server:11.0.3.Final-1
-    docker_native: quay.io/infinispan/server-native:11.0.3.Final-1
+    server: https://downloads.jboss.org/infinispan/11.0.4.Final/infinispan-server-11.0.4.Final.zip
+    wfmodules: https://downloads.jboss.org/infinispan/11.0.4.Final/infinispan-wildfly-modules-11.0.4.Final.zip
+    docker: quay.io/infinispan/server:11.0.4.Final-1
+    docker_native: quay.io/infinispan/server-native:11.0.4.Final-1
   docs:
     # --- Stable Operator version. ---
     operator: /infinispan-operator/2.0.x/operator.html
@@ -530,7 +530,7 @@ hotrod:
     title: Java
     text: clients/java.html.haml
     maven_artifact_id: infinispan-client-hotrod
-    version: 11.0.3.Final
+    version: 11.0.4.Final
 # Uncomment this section if an unstable Java Hot Rod client is available
   java_unstable:
     title: Java
@@ -812,7 +812,7 @@ docs:
         alias: dev
     11.0.x:
       core:
-        html: org.infinispan:infinispan-docs:11.0.3.Final:zip:html
+        html: org.infinispan:infinispan-docs:11.0.4.Final:zip:html
         alias: stable
     10.1.x:
       core:

--- a/_config/ispn.yml
+++ b/_config/ispn.yml
@@ -50,15 +50,15 @@ stable:
 # Please remove or comment out the following 'unstable' version section if this is not applicable at the moment.
 unstable:
   minor_version: 12.0
-  version: 12.0.0.Dev04
-  maven_latest: 12.0.0.Dev04
+  version: 12.0.0.Dev05
+  maven_latest: 12.0.0.Dev05
   release_date: 2020/09/28
-  fixed_issues: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310799&version=12347254
+  fixed_issues: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310799&version=12350773
   codename: N/A
   whats_new: Hibernate Search 6 + Lucene 8, Documentation improvement, Cross Site Replication Conflict Resolution, Console improvements
   download:
-    server: https://downloads.jboss.org/infinispan/12.0.0.Dev04/infinispan-server-12.0.0.Dev04.zip
-    wfmodules: https://downloads.jboss.org/infinispan/12.0.0.Dev04/infinispan-wildfly-modules-12.0.0.Dev04.zip
+    server: https://downloads.jboss.org/infinispan/12.0.0.Dev05/infinispan-server-12.0.0.Dev05.zip
+    wfmodules: https://downloads.jboss.org/infinispan/12.0.0.Dev05/infinispan-wildfly-modules-12.0.0.Dev05.zip
     docker: quay.io/infinispan/server:12.0
   docs:
     operator: /infinispan-operator/master/operator.html
@@ -536,7 +536,7 @@ hotrod:
     title: Java
     text: clients/java.html.haml
     maven_artifact_id: infinispan-client-hotrod
-    version: 12.0.0.Dev04
+    version: 12.0.0.Dev05
   cpp:
     title: C++ Client
     version: 8.3.2.Final
@@ -808,7 +808,7 @@ docs:
   infinispan:
     12.0.x:
       core:
-        html: org.infinispan:infinispan-docs:12.0.0.Dev04:zip:html
+        html: org.infinispan:infinispan-docs:12.0.0.Dev05:zip:html
         alias: dev
     11.0.x:
       core:

--- a/_config/ispn.yml
+++ b/_config/ispn.yml
@@ -539,7 +539,7 @@ hotrod:
     version: 12.0.0.Dev04
   cpp:
     title: C++ Client
-    version: 8.3.1.Final
+    version: 8.3.2.Final
     text: clients/cpp.html.haml
     github: https://github.com/infinispan/cpp-client
     docs_with_version: /hotrod-clients/cpp/docs
@@ -558,15 +558,15 @@ hotrod:
 #        docs_version: 8.3.0.Beta1
       class_stable: Stable
       win64_laststable:
-        title: 8.3.1.Final Windows x86/64 bit
-        download: https://downloads.jboss.org/infinispan/HotRodCPP/8.3.1.Final/infinispan-hotrod-cpp-8.3.1.Final-WIN-x86_64.zip
+        title: 8.3.2.Final Windows x86/64 bit
+        download: https://downloads.jboss.org/infinispan/HotRodCPP/8.3.2.Final/infinispan-hotrod-cpp-8.3.2.Final-WIN-x86_64.zip
       rhel64_laststable:
-        title: 8.3.1.Final RHEL x86/64 bit
-        download: https://downloads.jboss.org/infinispan/HotRodCPP/8.3.1.Final/infinispan-hotrod-cpp-8.3.1.Final-RHEL-x86_64.rpm
+        title: 8.3.2.Final RHEL x86/64 bit
+        download: https://downloads.jboss.org/infinispan/HotRodCPP/8.3.2.Final/infinispan-hotrod-cpp-8.3.2.Final-RHEL-x86_64.rpm
       sources_laststable:
-        title: 8.3.1.Final Sources
-        download: https://downloads.jboss.org/infinispan/HotRodCPP/8.3.1.Final/infinispan-hotrod-cpp-8.3.1.Final-Source.zip
-        docs_version: 8.3.1.Final
+        title: 8.3.2.Final Sources
+        download: https://downloads.jboss.org/infinispan/HotRodCPP/8.3.2.Final/infinispan-hotrod-cpp-8.3.2.Final-Source.zip
+        docs_version: 8.3.2.Final
       class_old: Archive
       win64_lateststable:
         title: 8.2.1.Final Windows x86/64 bit
@@ -613,7 +613,7 @@ hotrod:
         docs_version: 7.0.0.Final
   dotnet:
     title: .NET Client
-    version: 8.3.1.Final
+    version: 8.3.2.Final
     text: clients/dotnet.html.haml
     github: https://github.com/infinispan/dotnet-client
     docs_with_version: /hotrod-clients/dotnet/docs
@@ -628,12 +628,12 @@ hotrod:
 #        docs_version: 8.3.0.Beta1
       class_stable: Stable
       msi_stable:
-        title: 8.3.1.Final Windows msi x86/64 bit only
-        download: https://downloads.jboss.org/infinispan/HotRodCSharp/8.3.1.Final/infinispan-hotrod-dotnet-8.3.1.Final.msi
+        title: 8.3.2.Final Windows msi x86/64 bit only
+        download: https://downloads.jboss.org/infinispan/HotRodCSharp/8.3.2.Final/infinispan-hotrod-dotnet-8.3.2.Final.msi
       sources_stable:
-        title: 8.3.1.Final Sources
-        download: https://downloads.jboss.org/infinispan/HotRodCSharp/8.3.1.Final/infinispan-hotrod-dotnet-8.3.1.Final-Source.zip
-        docs_version: 8.3.1.Final
+        title: 8.3.2.Final Sources
+        download: https://downloads.jboss.org/infinispan/HotRodCSharp/8.3.2.Final/infinispan-hotrod-dotnet-8.3.2.Final-Source.zip
+        docs_version: 8.3.2.Final
       class_old: Archive
       msi_lateststable:
         title: 8.2.1.Final Windows msi x86/64 bit only

--- a/bin/fetch_docs.rb
+++ b/bin/fetch_docs.rb
@@ -155,6 +155,8 @@ cfg["ispn_operator"].each do |version, sub|
   end
   %x( mkdir -p _site/infinispan-operator/#{version}/ )
   %x( mv _optmp/*.html "_site/infinispan-operator/#{version}/" )
+  %x( mkdir -p _site/infinispan-operator/topics/images/ )
+  %x( mv _optmp/*.svg "_site/infinispan-operator/topics/images/" )
   %x( rm -rf _optmp* )
 end
 

--- a/images/roadmap.svg
+++ b/images/roadmap.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    viewBox="0 0 730.46863 92.989116"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
    sodipodi:docname="roadmap.svg">
   <defs
      id="defs4">
@@ -107,7 +105,8 @@
      fit-margin-top="0.5"
      fit-margin-left="0.5"
      fit-margin-right="0.5"
-     fit-margin-bottom="0.5" />
+     fit-margin-bottom="0.5"
+     inkscape:document-rotation="0" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -266,9 +265,10 @@
                    height="56.42857"
                    x="55"
                    y="-0.53712875" /></flowRegion><flowPara
-                 id="flowPara4391">7.2April 20</flowPara></flowRoot>            <text
+                 id="flowPara4391">7.2April 20</flowPara></flowRoot>
+            <text
                xml:space="preserve"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11120605px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                x="3216.2615"
                y="8393.5947"
                id="text4395"><tspan
@@ -276,7 +276,7 @@
                  id="tspan4397"
                  x="3216.2615"
                  y="8393.5947"
-                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.66668701px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">10.1</tspan><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.667px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">10.1</tspan><tspan
                  sodipodi:role="line"
                  x="3216.2615"
                  y="10157.483"
@@ -284,7 +284,7 @@
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:635px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">December 2020</tspan></text>
             <text
                xml:space="preserve"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11120605px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                x="8176.9517"
                y="8393.5947"
                id="text4395-4"><tspan
@@ -292,7 +292,7 @@
                  id="tspan4397-0"
                  x="8176.9517"
                  y="8393.5947"
-                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.66668701px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">11.0</tspan><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.667px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">11.0</tspan><tspan
                  sodipodi:role="line"
                  x="8176.9517"
                  y="10157.483"
@@ -300,7 +300,7 @@
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:635px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">June 2020</tspan></text>
             <text
                xml:space="preserve"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11120605px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                x="18112.816"
                y="8393.5947"
                id="text4395-4-7-9"><tspan
@@ -308,15 +308,14 @@
                  id="tspan4397-0-5-9"
                  x="18112.816"
                  y="8393.5947"
-                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.66668701px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">...</tspan><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.667px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1">...</tspan><tspan
                  sodipodi:role="line"
                  x="18112.816"
                  y="10157.483"
-                 id="tspan4399-9-6-2"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:635px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1" /></text>
+                 id="tspan4399-9-6-2" /></text>
             <text
                xml:space="preserve"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.1114502px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1411.11px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                x="13100.293"
                y="8393.5947"
                id="text4395-4-4"><tspan
@@ -324,12 +323,12 @@
                  id="tspan4397-0-0"
                  x="13100.293"
                  y="8393.5947"
-                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.66680908px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1;stroke-width:1.00000012px">12.0</tspan><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:846.667px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Bold';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1;stroke-width:1px">12.0</tspan><tspan
                  sodipodi:role="line"
                  x="13100.293"
-                 y="10157.484"
+                 y="10157.482"
                  id="tspan4399-9-3"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:635.00006104px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1;stroke-width:1.00000012px">September 2020</tspan></text>
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:635px;line-height:125%;font-family:'Titillium Web';-inkscape-font-specification:'Titillium Web, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#656565;fill-opacity:1;stroke-width:1px">December 2020</tspan></text>
           </g>
         </g>
       </g>


### PR DESCRIPTION
Operator 2.0.x and master branches are missing the xsite image in documentation. This fix adds all svg images to an unversioned directory. Images in documentation shouldn't generally be versioned so I don't think it matters like it would for html.