### PR TITLE
adding bigdecimal gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :jekyll_plugins do
   gem 'jekyll-paginate-v2'
   gem 'jekyll-archives'
   gem 'optimist'
+  gem 'bigdecimal'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     asciidoctor (2.0.12)
+    bigdecimal (2.0.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.7)
     em-websocket (0.5.2)
@@ -81,6 +82,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal
   jekyll (~> 4.0)
   jekyll-archives
   jekyll-asciidoc


### PR DESCRIPTION
Fixes: 

bundler: failed to load command: jekyll (/home/infinispan/.bundle/ruby/2.5.0/bin/jekyll)
LoadError: cannot load such file -- bigdecimal
  /home/infinispan/.bundle/ruby/2.5.0/gems/liquid-4.0.3/lib/liquid/standardfilters.rb:2:in `require'
  /home/infinispan/.bundle/ruby/2.5.0/gems/liquid-4.0.3/lib/liquid/standardfilters.rb:2:in `<top (required)>'
  /home/infinispan/.bundle/ruby/2.5.0/gems/liquid-4.0.3/lib/liquid.rb:72:in `require'
  /home/infinispan/.bundle/ruby/2.5.0/gems/liquid-4.0.3/lib/liquid.rb:72:in `<top (required)>'
  /home/infinispan/.bundle/ruby/2.5.0/gems/jekyll-4.1.1/lib/jekyll.rb:35:in `require'
  /home/infinispan/.bundle/ruby/2.5.0/gems/jekyll-4.1.1/lib/jekyll.rb:35:in `<top (required)>'
  /home/infinispan/.bundle/ruby/2.5.0/gems/jekyll-4.1.1/exe/jekyll:8:in `require'
  /home/infinispan/.bundle/ruby/2.5.0/gems/jekyll-4.1.1/exe/jekyll:8:in `<top (required)>'
  /home/infinispan/.bundle/ruby/2.5.0/bin/jekyll:23:in `load'
  /home/infinispan/.bundle/ruby/2.5.0/bin/jekyll:23:in `<top (required)>'