### PR TITLE
Add missing --net=host in podman cmd line

### DIFF
--- a/_layouts/get-started.html
+++ b/_layouts/get-started.html
@@ -14,7 +14,7 @@ layout: base
       <h3>Get Infinispan</h3>
       <p>Add a username and password, then run the one of the following commands:
         <pre><code>
-podman run -it -e USER="username" -e PASS="password" quay.io/infinispan/server:11.0
+podman run -it -e USER="username" -e PASS="password" --net=host quay.io/infinispan/server:11.0
         </code></pre></p>
         <pre><code>
 docker run -it -p 11222:11222 -e USER="username" -e PASS="password" infinispan/server:11.0


### PR DESCRIPTION
The Podman command requires --net=host to bind to localhost, otherwise the app isn't accessible