### PR TITLE
issue-227 Hot Rod client docs

### DIFF
--- a/_data/ispn.yml
+++ b/_data/ispn.yml
@@ -613,6 +613,8 @@ hotrod:
     github: https://github.com/infinispan/cpp-client
     #Update latest stable docs directory under "docs/hotrod-clients/cpp/docs"
     docs_with_version: /hotrod-clients/cpp/docs/8.3.2.Final
+    #Use latest documentation version
+    main_docs: /docs/hotrod-clients/cpp/latest/cpp_client.html
     # Comment this out if no downloads are available
     downloads:
       #      class_unstable: Development
@@ -688,6 +690,8 @@ hotrod:
     github: https://github.com/infinispan/dotnet-client
     #Update latest stable docs directory under "docs/hotrod-clients/dotnet/docs"
     docs_with_version: /hotrod-clients/dotnet/docs/8.3.2.Final
+    #Use latest documentation version
+    main_docs: /docs/hotrod-clients/dotnet/latest/dotnet_client.html
     downloads:
       #      class_unstable: Development
       #      msi_unstable:
@@ -735,6 +739,9 @@ hotrod:
     version: 0.6.0
     text: clients/javascript.html
     github: https://github.com/infinispan/js-client
+    #Use latest documentation version
+    main_docs: /docs/hotrod-clients/js/latest/js_client.html
+    # Need to remove this docs reference after making sure its not used.
     docs: https://github.com/infinispan/js-client/blob/main/README.md
     external_artifact_type: npm
     external_artifact_build_file: package.json
@@ -1123,7 +1130,34 @@ ispn_operator:
     zip-url: https://github.com/infinispan/infinispan-operator/archive/1.1.x.zip
 
 # -----------------------------
-# 7. Spring Boot Starter
+# Hot Rod JavaScript client
+# -----------------------------
+
+hr_js_client:
+  main:
+    zip-url: https://github.com/infinispan/js-client/archive/main.zip
+    docs: /docs/hotrod-clients/js/latest/js_client.html
+
+# -----------------------------
+# Hot Rod C++ client
+# -----------------------------
+
+hr_cpp_client:
+  main:
+    zip-url: https://github.com/infinispan/dotnet-client/archive/main.zip
+    docs: /docs/hotrod-clients/cpp/latest/cpp_client.html
+
+# -----------------------------
+# Hot Rod .NET/C# client
+# -----------------------------
+
+hr_dotnet_client:
+  main:
+    zip-url: https://github.com/infinispan/dotnet-client/archive/main.zip
+    docs: /docs/hotrod-clients/dotnet/latest/dotnet_client.html
+
+# -----------------------------
+# Spring Boot Starter
 # -----------------------------
 
 sb_starter:

--- a/_includes/documentation-links-band.html
+++ b/_includes/documentation-links-band.html
@@ -59,13 +59,22 @@
           <a href="{{site.data.ispn.stable.docs.rest}}" target="_blank">REST API</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.hotrod}}" target="_blank">Hot Rod Java Client Guide</a>
-        </li>
-        <li>
           <a href="{{site.data.ispn.stable.docs.integrations}}" target="_blank">Integrations</a>
         </li>
         <li>
           <a href="{{site.data.ispn.stable.docs.starter}}" target="_blank">Spring Boot Starter</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.stable.docs.hotrod}}" target="_blank">Java Client Guide</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.hr_js_client.main.docs}}" target="_blank">Node.JS Client Guide</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.hr_cpp_client.main.docs}}" target="_blank">C++ Client Guide</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.hr_dotnet_client.main.docs}}" target="_blank">.NET/C# Client Guide</a>
         </li>
       </ul>
     </div>

--- a/_includes/download-hotrod-band.html
+++ b/_includes/download-hotrod-band.html
@@ -8,8 +8,8 @@
           {% assign text = entry[1].text %}
           <p class="margin-tb-sm">{% include {{ text }} %}</p>
 
-          {% if entry[1].docs_with_version %}
-            <i class="fas fa-book text-orange"></i> <a href="{{ entry[1].docs_with_version }}"> Documentation</a>
+          {% if entry[1].main_docs %}
+            <i class="fas fa-book text-orange"></i> <a href="{{ entry[1].main_docs }}"> Documentation</a>
             <br/>
           {% endif %}
 

--- a/_plugins/fetch_docs.rb
+++ b/_plugins/fetch_docs.rb
@@ -160,6 +160,63 @@ else
     end
   end
 
+  # Hot Rod JS client latest
+  cfg["hr_js_client"].each do |version, sub|
+    puts "#{version} wget"
+    zipUrl = sub["zip-url"]
+    puts "#{version} wget #{zipUrl}"
+    %x( wget #{zipUrl} -O _jstmp.zip)
+    %x( unzip _jstmp.zip "*documentation/*" -d _jstmp)
+    Dir.glob("_jstmp/**/*.asciidoc").each do |f|
+      %x( asciidoctor #{f} )
+    end
+    Dir.glob("_jstmp/**/*.html").each do |f|
+      %x( cp -r #{f} _jstmp )
+    end
+    %x( mkdir -p docs/hotrod-clients/js/latest/ )
+    %x( mv _jstmp/*.html "docs/hotrod-clients/js/latest/" )
+    %x( rm -rf _jstmp* )
+    operatorDocIndex.push "main"
+  end
+
+  # Hot Rod C++ client latest
+  cfg["hr_cpp_client"].each do |version, sub|
+    puts "#{version} wget"
+    zipUrl = sub["zip-url"]
+    puts "#{version} wget #{zipUrl}"
+    %x( wget #{zipUrl} -O _cpptmp.zip)
+    %x( unzip _cpptmp.zip "*documentation/*" -d _cpptmp)
+    Dir.glob("_cpptmp/**/*.asciidoc").each do |f|
+      %x( asciidoctor #{f} )
+    end
+    Dir.glob("_cpptmp/**/*.html").each do |f|
+      %x( cp -r #{f} _cpptmp )
+    end
+    %x( mkdir -p docs/hotrod-clients/cpp/latest/ )
+    %x( mv _cpptmp/*.html "docs/hotrod-clients/cpp/latest/" )
+    %x( rm -rf _cpptmp* )
+    operatorDocIndex.push "main"
+  end
+
+  # Hot Rod .NET/C# client latest
+  cfg["hr_dotnet_client"].each do |version, sub|
+    puts "#{version} wget"
+    zipUrl = sub["zip-url"]
+    puts "#{version} wget #{zipUrl}"
+    %x( wget #{zipUrl} -O _dotnettmp.zip)
+    %x( unzip _dotnettmp.zip "*documentation/*" -d _dotnettmp)
+    Dir.glob("_dotnettmp/**/*.asciidoc").each do |f|
+      %x( asciidoctor #{f} )
+    end
+    Dir.glob("_dotnettmp/**/*.html").each do |f|
+      %x( cp -r #{f} _dotnettmp )
+    end
+    %x( mkdir -p docs/hotrod-clients/dotnet/latest/ )
+    %x( mv _dotnettmp/*.html "docs/hotrod-clients/dotnet/latest/" )
+    %x( rm -rf _dotnettmp* )
+    operatorDocIndex.push "main"
+  end
+
   # and then it's operator's turn
   cfg["ispn_operator"].each do |version, sub|
     puts "#{version} wget"


### PR DESCRIPTION
This adds links to Hot Rod C++, .NET/C#, and JS client docs to the main documentation page. It also updates the client download page to add JS doc links.

Additionally this PR means that client docs will always come from the main branch. I think it is reasonable for community to refer to latest client docs always.