### PR TITLE
Improve documentation page

### DIFF
--- a/_includes/documentation-guides-band.html
+++ b/_includes/documentation-guides-band.html
@@ -22,6 +22,9 @@
         <li>
           <a href="{{site.data.ispn.unstable.docs.configdocs}}">Schema reference</a>
         </li>
+        <li>
+          <a href="{{site.data.ispn.unstable.docs.serverimage}}" target="_blank">Infinispan images</a>
+        </li>
       </ul>
     </div>
     {% endif %}
@@ -42,6 +45,9 @@
         </li>
         <li>
           <a href="{{site.data.ispn.stable.docs.configdocs}}">Schema reference</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.unstable.docs.serverimage}}" target="_blank">Infinispan images</a>
         </li>
       </ul>
     </div>

--- a/_includes/documentation-guides-band.html
+++ b/_includes/documentation-guides-band.html
@@ -1,60 +1,53 @@
 <div class="component documentation-guides-band full-width-bg dark-bg light-blue">
   <div class="grid-wrapper">
     <div class="width-12-12">
-      <h3>Infinispan Guides</h3>
-      <p>Get answers and find help in the Infinispan documentation set.</p>
+      <h3>Documentation Index</h3>
     </div>
     {% if site.data.ispn.unstable %}
     <div class="width-4-12 width-12-12-m">
-      <h4><i class="fas fa-wrench"></i> Development (Infinispan {{site.data.ispn.unstable.minor_version}})</h4>
+      <h4><i class="fas fa-wrench"></i> Development ({{site.data.ispn.unstable.minor_version}})</h4>
       <ul class="chevron">
         <li>
-          <a href="{{site.data.ispn.unstable.docs.home}}">Documentation Index</a>
+          <a href="{{site.data.ispn.unstable.docs.home}}">{{site.data.ispn.unstable.minor_version}} documentation</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.unstable.docs.operator}}" target="_blank">Infinispan Operator Guide</a>
+          <a href="{{site.data.ispn.unstable.docs.operator}}" target="_blank">Infinispan Operator</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.unstable.docs.serverimage}}" target="_blank">Infinispan Server Image</a>
+          <a href="{{site.baseurl}}/hotrod-clients" target="_blank">Hot Rod clients</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.unstable.docs.javadocs}}">JavaDocs</a>
+          <a href="{{site.data.ispn.unstable.docs.javadocs}}">Java API</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.unstable.docs.configdocs}}">Configuration Schema</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.unstable.docs.jmxdocs}}">JMX Reference</a>
+          <a href="{{site.data.ispn.unstable.docs.configdocs}}">Schema reference</a>
         </li>
       </ul>
     </div>
     {% endif %}
     <div class="width-4-12 width-12-12-m">
-      <h4><i class="fas fa-check-circle"></i> Stable (Infinispan {{site.data.ispn.stable.minor_version}})</h4>
+      <h4><i class="fas fa-check-circle"></i> Stable ({{site.data.ispn.stable.minor_version}})</h4>
       <ul class="chevron">
         <li>
-          <a href="{{site.data.ispn.stable.docs.home}}">Documentation Index</a>
+          <a href="{{site.data.ispn.stable.docs.home}}">{{site.data.ispn.stable.minor_version}} documentation</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.operator}}" target="_blank">Infinispan Operator Guide</a>
+          <a href="{{site.data.ispn.stable.docs.operator}}" target="_blank">Infinispan Operator</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.serverimage}}" target="_blank">Infinispan Server Image</a>
+          <a href="{{site.baseurl}}/hotrod-clients" target="_blank">Hot Rod clients</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.javadocs}}">JavaDocs</a>
+          <a href="{{site.data.ispn.stable.docs.javadocs}}">Java API</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.configdocs}}">Configuration Schema</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.jmxdocs}}">JMX Reference</a>
+          <a href="{{site.data.ispn.stable.docs.configdocs}}">Schema reference</a>
         </li>
       </ul>
     </div>
     <div class="width-4-12 width-12-12-m">
-      <h4>Find documentation for older versions of Infinispan.</h4>
-      <i class="fas fa-book"></i> <a href="{{site.baseurl}}/documentation-archive">Documentation Archive</a>
+      <h4>Previous releases</h4>
+      <i class="fas fa-book"></i> <a href="{{site.baseurl}}/documentation-archive">Documentation archive</a>
     </div>
   </div>
 </div>

--- a/_includes/documentation-links-band.html
+++ b/_includes/documentation-links-band.html
@@ -1,13 +1,13 @@
 <div class="component documentation-links-band">
   <div class="grid-wrapper">
     <div class="width-3-12 width-12-12-m contrib-block">
-      <h4>Getting Started</h4>
+      <h4><i class="fas fa-keyboard"></i> Get Started</h4>
       <ul class="chevron orange">
         <li>
-          <a href="{{site.baseurl}}/get-started/" target="_blank">Quick start</a>
+          <a href="{{site.baseurl}}/get-started/" target="_blank">4 easy steps</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.quickstart}}" target="_blank">Get up and running</a>
+          <a href="{{site.data.ispn.stable.docs.quickstart}}" target="_blank">Getting started with Infinispan</a>
         </li>
         <li>
           <a href="{{site.baseurl}}/tutorials/" target="_blank">Code tutorials</a>
@@ -15,7 +15,7 @@
       </ul>
     </div>
     <div class="width-3-12 width-12-12-m contrib-block">
-      <h4>Operations</h4>
+      <h4><i class="fas fa-server"></i> Operations</h4>
       <ul class="chevron orange">
         <li>
           <a href="{{site.data.ispn.stable.docs.operator}}" target="_blank">Infinispan Operator</a>
@@ -27,12 +27,15 @@
           <a href="{{site.data.ispn.stable.docs.server}}" target="_blank">Guide to Infinispan Server</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.unstable.docs.serverimage}}" target="_blank">Infinispan Server container image</a>
+          <a href="{{site.data.ispn.stable.docs.cli}}" target="_blank">Command Line Interface</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.stable.docs.rest}}" target="_blank">REST API</a>
         </li>
       </ul>
     </div>
     <div class="width-3-12 width-12-12-m contrib-block">
-      <h4>Developers</h4>
+      <h4><i class="fas fa-code"></i> Developers</h4>
       <ul class="chevron orange">
         <li>
           <a href="{{site.data.ispn.stable.docs.embedded}}" target="_blank">Embedding Infinispan</a>
@@ -55,7 +58,7 @@
       </ul>
     </div>
     <div class="width-3-12 width-12-12-m contrib-block">
-      <h4>Community</h4>
+      <h4><i class="fas fa-user-friends"></i> Community</h4>
       <ul class="chevron orange">
         <li>
           <a href="https://quarkus.io/guides/infinispan-client" target="_blank">Quarkus</a>

--- a/_includes/documentation-links-band.html
+++ b/_includes/documentation-links-band.html
@@ -1,125 +1,61 @@
 <div class="component documentation-links-band">
   <div class="grid-wrapper">
     <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-get-started.png">
-      <h4>Get Started</h4>
+      <h4>Getting Started</h4>
       <ul class="chevron orange">
         <li>
-          <a href="{{site.baseurl}}/get-started/" target="_blank">Run Infinispan in 4 Easy Steps</a>
+          <a href="{{site.baseurl}}/get-started/" target="_blank">Quick start</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.quickstart}}" target="_blank">Get Up and Running with Infinispan</a>
+          <a href="{{site.data.ispn.stable.docs.quickstart}}" target="_blank">Get up and running</a>
         </li>
         <li>
-          <a href="{{site.baseurl}}/tutorials/" target="_blank">Tutorials</a>
+          <a href="{{site.baseurl}}/tutorials/" target="_blank">Code tutorials</a>
         </li>
       </ul>
     </div>
     <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-server.png">
-      <h4>Server</h4>
+      <h4>Operations</h4>
       <ul class="chevron orange">
         <li>
-          <a href="{{site.data.ispn.stable.docs.server}}" target="_blank">Infinispan Server Guide</a>
+          <a href="{{site.data.ispn.stable.docs.operator}}" target="_blank">Infinispan Operator</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.cli}}" target="_blank">Command Line Interface</a>
+          <a href="{{site.data.ispn.stable.docs.helmchart}}" target="_blank">Helm Chart</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.rest}}" target="_blank">REST API</a>
+          <a href="{{site.data.ispn.stable.docs.server}}" target="_blank">Guide to Infinispan Server</a>
+        </li>
+        <li>
+          <a href="{{site.data.ispn.unstable.docs.serverimage}}" target="_blank">Infinispan Server container image</a>
         </li>
       </ul>
     </div>
     <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-clients.png">
-      <h4>Clients</h4>
-      <ul class="chevron orange">
-        <li>
-          <a href="{{site.data.ispn.stable.docs.hotrod}}" target="_blank">Java Client Guide</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.hr_js_client.main.docs}}" target="_blank">Node.JS Client Guide</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.hr_cpp_client.main.docs}}" target="_blank">C++ Client Guide</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.hr_dotnet_client.main.docs}}" target="_blank">.NET/C# Client Guide</a>
-        </li>
-      </ul>
-    </div>
-    <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-cloud.png">
-      <h4>Cloud</h4>
-      <ul class="chevron orange">
-        <li>
-          <a href="{{site.data.ispn.stable.docs.operator}}" target="_blank">Infinispan Operator Guide</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.helmchart}}" target="_blank">Infinispan Helm Chart</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.serverimage}}" target="_blank">Infinispan Server Image</a>
-        </li>
-      </ul>
-    </div>
-    <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-developers.png">
-      <h4>Developer</h4>
+      <h4>Developers</h4>
       <ul class="chevron orange">
         <li>
           <a href="{{site.data.ispn.stable.docs.embedded}}" target="_blank">Embedding Infinispan</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.config}}" target="_blank">Configuring Infinispan Caches</a>
+          <a href="{{site.data.ispn.stable.docs.hotrod}}" target="_blank">Using Java clients</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.encoding}}" target="_blank">Cache Encoding and Marshalling</a>
+          <a href="{{site.data.ispn.stable.docs.config}}" target="_blank">Configuring caches</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.query}}" target="_blank">Querying Infinispan Caches</a>
+          <a href="{{site.data.ispn.stable.docs.encoding}}" target="_blank">Encoding caches and marshalling data</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.xsite}}" target="_blank">Cross-Site Replication</a>
+          <a href="{{site.data.ispn.stable.docs.query}}" target="_blank">Querying caches</a>
         </li>
         <li>
-          <a href="{{site.data.ispn.stable.docs.dev}}" target="_blank">Developer's Guide to Infinispan</a>
+          <a href="{{site.data.ispn.stable.docs.xsite}}" target="_blank">Cross-site replication</a>
         </li>
       </ul>
     </div>
     <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-admin.png">
-      <h4>Admin</h4>
-      <ul class="chevron orange">
-        <li>
-          <a href="{{site.data.ispn.stable.docs.upgrade}}" target="_blank">Upgrading Infinispan</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.security}}" target="_blank">Securing Infinispan</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.tuning}}" target="_blank">Tuning Performance</a>
-        </li>
-      </ul>
-    </div>
-    <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-integrations.png">
-      <h4>Integrations</h4>
-      <ul class="chevron orange">
-        <li>
-          <a href="{{site.data.ispn.stable.docs.starter}}" target="_blank">Spring Boot Starter</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.spring}}" target="_blank">Spring Cache/Sessions</a>
-        </li>
-        <li>
-          <a href="{{site.data.ispn.stable.docs.hibernate}}" target="_blank">Hibernate Cache</a>
-        </li>
-      </ul>
-    </div>
-    <div class="width-3-12 width-12-12-m contrib-block">
-      <img src="{{site.baseurl}}/assets/images/documentation/icon-external-integrations.png">
-      <h4>Community Projects</h4>
+      <h4>Community</h4>
       <ul class="chevron orange">
         <li>
           <a href="https://quarkus.io/guides/infinispan-client" target="_blank">Quarkus</a>

--- a/documentation.md
+++ b/documentation.md
@@ -1,6 +1,6 @@
 ---
 layout: documentation
-title: Documentation
-subtitle: Find help and knowledge straight from the source!
+title: Guides
+#subtitle: Get help and share knowledge with the Infinispan community
 permalink: /documentation/
 ---


### PR DESCRIPTION
Propose we remove the icons and reduce the noise on the documentation landing page. Trying to have the "kitchen sink" with all the links makes it harder to navigate. 