### PR TITLE
ISPN-16679 Instant cache snapshot switching blog post

### DIFF
--- a/_posts/2024-05-30-cache-alias.adoc
+++ b/_posts/2024-05-30-cache-alias.adoc
@@ -1,0 +1,23 @@
+---
+layout: blog
+title: Instant Switching of Cache Snapshots
+permalink: /blog/:year/:month/:day/cache-snapshots
+date: '2024-05-30T00:00:00.000-00:00'
+author: ttarrant
+tags: [ "alias", "snapshots" ]
+---
+
+= Instant Switching of Cache Snapshots
+
+Populating a cache with data is usually done in two ways:
+
+* on-demand: whenever an application needs an item of data, it checks the cache first and, if a miss occurs, retrieves the data from a third-party system (a database or an external service) and inserts it in the cache for further use.
+* batched: at a specified time, a dedicated task retrieves all of the data that should be cached and refreshes the content of the cache, often using bulk operations to optimize write performance
+
+The *on-demand* scenario relies on expiration and/or eviction policies to control how much data is kept in the cache and for how long. The *batch* scenario keeps the whole data set in the cache until the next refresh.
+
+Batch refreshing can use two approaches: either the cache is cleared before the new snapshot is written to it, or the entries are overwritten. The latter is only possible if the keys do not change between snapshots.
+
+In both approaches, however, it is possible for client applications to see an incomplete or inconsistent snapshot.
+
+Infinispan 15 introduced the concept of cache aliases. A cache alias is essentially another name by which clients can access the contents of a cache.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16679

This is still in draft because updating the cache aliases attribute cannot be done in a single operation yet.

Closes #368 
