### PR TITLE
Infinispan cache layer for Drupal and Wordpress

### DIFF
--- a/_posts/2024-06-21-cms-cache.adoc
+++ b/_posts/2024-06-21-cms-cache.adoc
@@ -1,0 +1,46 @@
+---
+layout: blog
+title: Infinispan as an Open Source cache layer for CMS
+permalink: /blog/:year/:month/:day/cms-cache
+date: '2024-06-21T00:00:00.000-00:00'
+author: rigazilla
+tags: [ "cms", "drupal", "wordpress", "php", "cache", "redis" ]
+---
+
+== Infinispan as an Open Source cache layer for CMS
+
+Those of you who are dealing with content management systems (CMS) know very well the importance of an efficient cache layer, especially when performance matters.
+
+In this regard, the Infinispan team wants to shine a spotlight on what we have done with the Infinispan 15 release to extend our compatibility with the Redis RESP protocol.
+
+We already generally spoke about this in a https://infinispan.org/blog/2024/02/02/infinispan-server-redis-clients[previous post], but here we want to focus on this specific field of application: CMS cache layer.
+
+We prefer to show rather than describe, so a couple of demos have been developed to show how easy it is to move from Redis, or other RESP databases, to an open source solution like Infinispan. As you will see it's easy as just changing the cache db endpoint.
+
+=== Demos
+
+Demos are available at https://github.com/rigazilla/demo-infinispan-php-resp and can be
+run on linux (bash) systems with git and docker.
+
+__At the moment Drupal and Wordpress have been considered, but the procedure can be easily extended to every application which rely on the RESP protocol.__
+
+Both demos work the same way and you really just need to follow the project README:
+
+1. a `demo-start.sh` commmand
+   - starts a CMS infrastructure with docker compose
+   - starts both Redis and Infinispan
+   - configure the CMS to use Redis
+2. a `switch-to-infinispan.sh` command
+   - changes the cache endpoint from Redis to Infinispan at runtime
+3. a `demo-stop.sh` command
+   - stops and cleanup everything
+
+As you can guess all the effort has been put to allow you to try this feature as easily as possible __(We know you're lazy, hackers!)__
+
+Hope you enjoy this new possibility we provided for you with Infinispan 15.
+
+Let us know your feedback and...
+
+happy coding!
+
+The Infinispan Team


### PR DESCRIPTION
Blog post about how it's easy to switch cache layer from Redis to Infinispan for Drupal and Wordpress.
please have a trip with the demo scripts while reviewing.
Follow the readme: https://github.com/rigazilla/demo-infinispan-php-resp
