### PR TITLE
Fixed link to release-notes on download-archive page

### DIFF
--- a/_layouts/download-archive.html
+++ b/_layouts/download-archive.html
@@ -58,7 +58,7 @@ layout: base
         {% endif %}
 
         <i class="fas fa-pencil-alt text-orange"></i>
-        <a href="{{site.baseurl}}/release-notes/#{{versions_hash[1].minor_version}}">Release Notes</a><br/>
+        <a href="{{site.baseurl}}/release-notes#{{versions_hash[1].minor_version}}">Release Notes</a><br/>
 
         <i class="fas fa-bug text-orange"></i>
         <a href="{{versions_hash[1].fixed_issues}}">Fixed issues</a><br/>


### PR DESCRIPTION
Links to release notes with slash in path part leads to "404 Page not found" error